### PR TITLE
Limit allowed `frame-ancestors` using CSP

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -83,6 +83,10 @@ The following variables as mandatory
 
 Set the value for the following variables - `MONGO_URI`, `MONGO_DBNAME`, `REDIS_HOST`, `REDIS_PORT`
 
+3. Configure `widget/nginx-variables.conf`.
+
+`set $FRAME_ANCESTORS "http:"`, to allow unencrypted iframing of the widget in your development environment.
+
 ## Installing dependencies and running app
 
 From the root folder run the following commands

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ docker-compose down
 sudo docker-compose up --build --force-recreate
 ```
 
+3. Configure `widget/nginx-variables.conf`.
+
+`set $FRAME_ANCESTORS "https://your.domain"`, to allow iframing of the widget on `your.domain`.
+
 ### 🛃 Manual
 
 WebWhiz is designed to be used as a production grade Chatbot that can be scaled up or down to handle any volume of data.
@@ -152,6 +156,10 @@ The following variables as mandatory
 2. Inside the workers folder create a copy of the `.env.sample` and rename as `.env`.
 
 Set the value for the following variables - `MONGO_URI`, `MONGO_DBNAME`, `REDIS_HOST`, `REDIS_PORT`
+
+3. Configure `widget/nginx-variables.conf`.
+
+`set $FRAME_ANCESTORS "http:"`, to allow unencrypted iframing of the widget in your development environment,
 
 #### Installing dependencies and running app
 

--- a/widget/Dockerfile
+++ b/widget/Dockerfile
@@ -26,6 +26,7 @@ COPY --from=builder_widget /app/dist /usr/share/nginx/html
 
 # Copying our nginx.conf
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY nginx-variables.conf /etc/nginx/nginx-variables.conf
 
 # Expose port
 EXPOSE 80

--- a/widget/nginx-variables.conf
+++ b/widget/nginx-variables.conf
@@ -1,0 +1,1 @@
+set $FRAME_ANCESTORS "'none'"; # Space delimited urls allowed to iframe the widget. If set to https: (without single quotes) all https sites are allowed

--- a/widget/nginx.conf
+++ b/widget/nginx.conf
@@ -1,5 +1,12 @@
 server {
+  include /etc/nginx/nginx-variables.conf;
+
   listen 80;
+
+  if ($FRAME_ANCESTORS) {
+    set $FRAME_ANCESTORS "frame-ancestors ${FRAME_ANCESTORS}";
+    add_header Content-Security-Policy "${FRAME_ANCESTORS}" always;
+  }
 
   location / {
     root /usr/share/nginx/html/;


### PR DESCRIPTION
Unset it or set it to `http: https:` to keep the previous behavior.

For self-hosting you would probably want to set it to `https://your.domain`.