### PR TITLE
Add header `X-Content-Type-Options "nosniff"`

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -5,6 +5,8 @@ upstream web {
 server {
   listen 80;
 
+  add_header X-Content-Type-Options "nosniff" always;
+
   location ~ ^/api(/?)(.*) {
     proxy_pass http://web/$2$is_args$args;
   }

--- a/widget/nginx.conf
+++ b/widget/nginx.conf
@@ -1,6 +1,8 @@
 server {
   listen 80;
 
+  add_header X-Content-Type-Options "nosniff" always;
+
   location / {
     root /usr/share/nginx/html/;
     include /etc/nginx/mime.types;


### PR DESCRIPTION
https://infosec.mozilla.org/guidelines/web_security#x-content-type-options
> all sites must set the X-Content-Type-Options header and the appropriate MIME types for files that they serve.